### PR TITLE
Fix: Install sbt in GitHub Actions workflow

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -23,7 +23,11 @@ jobs:
         curl -LO https://github.com/kaitai-io/kaitai_struct_compiler/releases/download/0.10/kaitai-struct-compiler_0.10_all.deb
         sudo apt-get install -y ./kaitai-struct-compiler_0.10_all.deb
     - name: Install sbt
-      run: sudo apt-get install sbt
+      run: |
+        sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 2EE0EA64E40A89B84B2DF73499E82A75642AC823
+        echo "deb https://repo.scala-sbt.org/scalasbt/debian all main" | sudo tee /etc/apt/sources.list.d/sbt.list
+        sudo apt-get update
+        sudo apt-get install sbt
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v5

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -22,6 +22,8 @@ jobs:
       run: |
         curl -LO https://github.com/kaitai-io/kaitai_struct_compiler/releases/download/0.10/kaitai-struct-compiler_0.10_all.deb
         sudo apt-get install -y ./kaitai-struct-compiler_0.10_all.deb
+    - name: Install sbt
+      run: sudo apt-get install sbt
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v5


### PR DESCRIPTION
This PR fixes the issue where sbt was not found during the GitHub Actions workflow by adding the official SBT repository to the apt sources.